### PR TITLE
Account delete

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -182,7 +182,8 @@ fn remove_account(id: &str) -> Result<(), String> {
     let client = Client::new(ClientConfig::default()).map_err(|err| err.to_string())?;
 
     let without_prefix = id.trim_start_matches("0x");
-    let account_id: u64 = u64::from_str_radix(&without_prefix, 16).unwrap();
+    let account_id: u64 =
+        u64::from_str_radix(&without_prefix, 16).map_err(|err| err.to_string())?;
     client
         .store()
         .remove_account(account_id)

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -32,6 +32,13 @@ pub enum AccountCmd {
         #[clap(short, long, default_value_t = false)]
         deploy: bool,
     },
+
+    /// Remove existing account from the local store
+    #[clap(short_flag = 'r')]
+    Remove {
+        #[clap()]
+        id: String,
+    },
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -64,6 +71,7 @@ impl AccountCmd {
                 new_account(template, *deploy)?;
             }
             AccountCmd::View { id: _ } => todo!(),
+            AccountCmd::Remove { id } => remove_account(id)?,
         }
         Ok(())
     }
@@ -165,5 +173,21 @@ fn new_account(template: &Option<AccountTemplate>, deploy: bool) -> Result<(), S
         })
         .map_err(|x| x.to_string())?;
 
+    Ok(())
+}
+
+// ACCOUNT REMOVE
+
+fn remove_account(id: &str) -> Result<(), String> {
+    let client = Client::new(ClientConfig::default()).map_err(|err| err.to_string())?;
+
+    let without_prefix = id.trim_start_matches("0x");
+    let account_id: u64 = u64::from_str_radix(&without_prefix, 16).unwrap();
+    client
+        .store()
+        .remove_account(account_id)
+        .map_err(|err| err.to_string())?;
+
+    println!("Succesfully removed Account ID: {}", id);
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,7 @@ pub enum StoreError {
     QueryError(rusqlite::Error),
     InputSerializationError(serde_json::Error),
     DataDeserializationError(serde_json::Error),
+    NotFound,
 }
 
 impl fmt::Display for StoreError {
@@ -53,6 +54,7 @@ impl fmt::Display for StoreError {
             DataDeserializationError(err) => {
                 write!(f, "error deserializing data from the store: {err}")
             }
+            NotFound => write!(f, "requested data was not found in the store"),
         }
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -136,13 +136,19 @@ impl Store {
     }
 
     pub fn remove_account(&self, account_id: u64) -> Result<(), StoreError> {
-        self.db
+        let q = self
+            .db
             .execute(
                 "DELETE FROM accounts WHERE id = ?",
                 params![account_id as i64],
             )
-            .map(|_| ())
-            .map_err(StoreError::QueryError)
+            .map_err(StoreError::QueryError)?;
+
+        if q == 0 {
+            return Err(StoreError::NotFound);
+        }
+
+        Ok(())
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -134,6 +134,16 @@ impl Store {
             .map(|_| ())
             .map_err(StoreError::QueryError)
     }
+
+    pub fn remove_account(&self, account_id: u64) -> Result<(), StoreError> {
+        self.db
+            .execute(
+                "DELETE FROM accounts WHERE id = ?",
+                params![account_id as i64],
+            )
+            .map(|_| ())
+            .map_err(StoreError::QueryError)
+    }
 }
 
 // STORE CONFIG


### PR DESCRIPTION
Adds `account delete` command to the CLI. 

Test:
1. Create account using `cargo run --release --features testing -- account new fungible-faucet -t TEST -d 10 -m 10000`
2. Get created account hexstring with `cargo run --release --features testing -- account list`
3. Remove account with `cargo run --release --features testing  -- account -r 0x880448d77a6ec824`
