### PR TITLE
persist accounts initial seed

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -93,15 +93,9 @@ impl AccountCmd {
                     },
                     AccountTemplate::NonFungibleFaucet => todo!(),
                 };
-                let (new_account, account_seed) = client
+                let (_new_account, _account_seed) = client
                     .new_account(client_template)
                     .map_err(|err| err.to_string())?;
-
-                println!(
-                    "New account created: {} with seed: {}",
-                    new_account.id(),
-                    format_word_to_single_hex(&account_seed)
-                );
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -133,15 +133,17 @@ fn list_accounts(client: Client) -> Result<(), String> {
             Cell::new("vault root").add_attribute(Attribute::Bold),
             Cell::new("storage root").add_attribute(Attribute::Bold),
             Cell::new("nonce").add_attribute(Attribute::Bold),
+            Cell::new("account seed").add_attribute(Attribute::Bold),
         ]);
 
-    accounts.iter().for_each(|acc| {
+    accounts.iter().for_each(|(acc, acc_seed)| {
         table.add_row(vec![
             acc.id().to_string(),
             acc.code_root().to_string(),
             acc.vault_root().to_string(),
             acc.storage_root().to_string(),
             acc.nonce().to_string(),
+            acc_seed.to_string(),
         ]);
     });
 
@@ -157,7 +159,7 @@ pub fn show_account(
     show_storage: bool,
     show_code: bool,
 ) -> Result<(), String> {
-    let account = client
+    let (account, account_seed) = client
         .get_account_by_id(account_id)
         .map_err(|err| err.to_string())?;
 
@@ -171,6 +173,7 @@ pub fn show_account(
             Cell::new("vault root").add_attribute(Attribute::Bold),
             Cell::new("storage root").add_attribute(Attribute::Bold),
             Cell::new("nonce").add_attribute(Attribute::Bold),
+            Cell::new("account seed").add_attribute(Attribute::Bold),
         ]);
 
     table.add_row(vec![
@@ -179,6 +182,7 @@ pub fn show_account(
         account.vault_root().to_string(),
         account.storage_root().to_string(),
         account.nonce().to_string(),
+        account_seed.to_string(),
     ]);
 
     println!("{table}\n");

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -93,11 +93,11 @@ impl AccountCmd {
                     },
                     AccountTemplate::NonFungibleFaucet => todo!(),
                 };
-                let new_account = client
+                let (new_account, account_seed) = client
                     .new_account(client_template)
                     .map_err(|err| err.to_string())?;
 
-                println!("New account created: {}", new_account.id());
+                println!("New account created: {} with seed: {}", new_account.id(), format_word_to_single_hex(&account_seed));
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
-    utils::{bytes_to_hex_string, Serializable}, Word, WORD_SIZE,
-    StarkField
+    utils::{bytes_to_hex_string, Serializable},
+    StarkField, Word, WORD_SIZE,
 };
 use miden_client::client::accounts;
 
@@ -97,7 +97,11 @@ impl AccountCmd {
                     .new_account(client_template)
                     .map_err(|err| err.to_string())?;
 
-                println!("New account created: {} with seed: {}", new_account.id(), format_word_to_single_hex(&account_seed));
+                println!(
+                    "New account created: {} with seed: {}",
+                    new_account.id(),
+                    format_word_to_single_hex(&account_seed)
+                );
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")
@@ -248,8 +252,8 @@ pub fn show_account(
     Ok(())
 }
 
-const BYTES_PER_FELT : usize = core::mem::size_of::<u64>();
-const BYTES_PER_WORD : usize = WORD_SIZE * BYTES_PER_FELT;
+const BYTES_PER_FELT: usize = core::mem::size_of::<u64>();
+const BYTES_PER_WORD: usize = WORD_SIZE * BYTES_PER_FELT;
 fn format_word_to_single_hex(word: &Word) -> String {
     let mut result = [0; BYTES_PER_WORD];
 

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -4,11 +4,10 @@ use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
     utils::{bytes_to_hex_string, Serializable},
-    StarkField, Word, WORD_SIZE,
 };
 use miden_client::client::accounts;
 
-use objects::{accounts::AccountId, assets::TokenSymbol};
+use objects::{accounts::AccountId, assets::TokenSymbol, Digest};
 
 // ACCOUNT COMMAND
 // ================================================================================================
@@ -136,7 +135,7 @@ fn list_accounts(client: Client) -> Result<(), String> {
         ]);
 
     accounts.iter().for_each(|(acc, acc_seed)| {
-        let formatted_seed = format_word_to_single_hex(acc_seed);
+        let formatted_seed = Digest::from(acc_seed).to_string();
 
         table.add_row(vec![
             acc.id().to_string(),
@@ -164,7 +163,7 @@ pub fn show_account(
         .get_account_by_id(account_id)
         .map_err(|err| err.to_string())?;
 
-    let formatted_seed = format_word_to_single_hex(&account_seed);
+    let formatted_seed = Digest::from(account_seed).to_string();
 
     let mut table = Table::new();
     table
@@ -244,17 +243,4 @@ pub fn show_account(
     }
 
     Ok(())
-}
-
-const BYTES_PER_FELT: usize = core::mem::size_of::<u64>();
-const BYTES_PER_WORD: usize = WORD_SIZE * BYTES_PER_FELT;
-fn format_word_to_single_hex(word: &Word) -> String {
-    let mut result = [0; BYTES_PER_WORD];
-
-    result[..8].copy_from_slice(&word[0].as_int().to_le_bytes());
-    result[8..16].copy_from_slice(&word[1].as_int().to_le_bytes());
-    result[16..24].copy_from_slice(&word[2].as_int().to_le_bytes());
-    result[24..].copy_from_slice(&word[3].as_int().to_le_bytes());
-
-    bytes_to_hex_string(result)
 }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -36,7 +36,10 @@ impl Client {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 
-    pub fn new_account(&mut self, template: AccountTemplate) -> Result<(Account, Word), ClientError> {
+    pub fn new_account(
+        &mut self,
+        template: AccountTemplate,
+    ) -> Result<(Account, Word), ClientError> {
         let mut rng = rand::thread_rng();
 
         let account_and_seed = match template {

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -36,10 +36,10 @@ impl Client {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 
-    pub fn new_account(&mut self, template: AccountTemplate) -> Result<Account, ClientError> {
+    pub fn new_account(&mut self, template: AccountTemplate) -> Result<(Account, Word), ClientError> {
         let mut rng = rand::thread_rng();
 
-        let account = match template {
+        let account_and_seed = match template {
             AccountTemplate::BasicWallet {
                 mutable_code,
                 storage_mode,
@@ -54,7 +54,7 @@ impl Client {
             }
         }?;
 
-        Ok(account)
+        Ok(account_and_seed)
     }
 
     fn new_basic_wallet(
@@ -62,7 +62,7 @@ impl Client {
         mutable_code: bool,
         rng: &mut ThreadRng,
         account_storage_mode: AccountStorageMode,
-    ) -> Result<Account, ClientError> {
+    ) -> Result<(Account, Word), ClientError> {
         if let AccountStorageMode::OnChain = account_storage_mode {
             todo!("Recording the account on chain is not supported yet");
         }
@@ -93,7 +93,7 @@ impl Client {
         .map_err(ClientError::AccountError)?;
 
         self.insert_account(&account, seed, &AuthInfo::RpoFalcon512(key_pair))?;
-        Ok(account)
+        Ok((account, seed))
     }
 
     fn new_fungible_faucet(
@@ -103,7 +103,7 @@ impl Client {
         max_supply: u64,
         rng: &mut ThreadRng,
         account_storage_mode: AccountStorageMode,
-    ) -> Result<Account, ClientError> {
+    ) -> Result<(Account, Word), ClientError> {
         if let AccountStorageMode::OnChain = account_storage_mode {
             todo!("On-chain accounts are not supported yet");
         }
@@ -129,7 +129,7 @@ impl Client {
         .map_err(ClientError::AccountError)?;
 
         self.insert_account(&account, seed, &AuthInfo::RpoFalcon512(key_pair))?;
-        Ok(account)
+        Ok((account, seed))
     }
 
     /// Inserts a new account into the client's store.

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -150,12 +150,15 @@ impl Client {
     /// Returns summary info about the accounts managed by this client.
     ///
     /// TODO: replace `AccountStub` with a more relevant structure.
-    pub fn get_accounts(&self) -> Result<Vec<AccountStub>, ClientError> {
+    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Digest)>, ClientError> {
         self.store.get_accounts().map_err(|err| err.into())
     }
 
     /// Returns summary info about the specified account.
-    pub fn get_account_by_id(&self, account_id: AccountId) -> Result<AccountStub, ClientError> {
+    pub fn get_account_by_id(
+        &self,
+        account_id: AccountId,
+    ) -> Result<(AccountStub, Digest), ClientError> {
         self.store
             .get_account_by_id(account_id)
             .map_err(|err| err.into())

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -1,5 +1,5 @@
 use super::Client;
-use crypto::Felt;
+use crypto::{Felt, Word};
 use miden_lib::AuthScheme;
 use objects::{
     accounts::{Account, AccountId, AccountStorage, AccountStub, AccountType},
@@ -77,7 +77,7 @@ impl Client {
         // we need to use an initial seed to create the wallet account
         let init_seed: [u8; 32] = rng.gen();
 
-        let (account, _seed) = if !mutable_code {
+        let (account, seed) = if !mutable_code {
             miden_lib::accounts::wallets::create_basic_wallet(
                 init_seed,
                 auth_scheme,
@@ -92,7 +92,7 @@ impl Client {
         }
         .map_err(ClientError::AccountError)?;
 
-        self.insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))?;
+        self.insert_account(&account, seed, &AuthInfo::RpoFalcon512(key_pair))?;
         Ok(account)
     }
 
@@ -118,7 +118,7 @@ impl Client {
         // we need to use an initial seed to create the wallet account
         let init_seed: [u8; 32] = rng.gen();
 
-        let (account, _seed) = miden_lib::accounts::faucets::create_basic_fungible_faucet(
+        let (account, seed) = miden_lib::accounts::faucets::create_basic_fungible_faucet(
             init_seed,
             token_symbol,
             decimals,
@@ -128,7 +128,7 @@ impl Client {
         )
         .map_err(ClientError::AccountError)?;
 
-        self.insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))?;
+        self.insert_account(&account, seed, &AuthInfo::RpoFalcon512(key_pair))?;
         Ok(account)
     }
 
@@ -136,10 +136,11 @@ impl Client {
     pub fn insert_account(
         &mut self,
         account: &Account,
+        account_seed: Word,
         auth_info: &AuthInfo,
     ) -> Result<(), ClientError> {
         self.store
-            .insert_account(account, auth_info)
+            .insert_account(account, account_seed, auth_info)
             .map_err(ClientError::StoreError)
     }
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -150,7 +150,7 @@ impl Client {
     /// Returns summary info about the accounts managed by this client.
     ///
     /// TODO: replace `AccountStub` with a more relevant structure.
-    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Digest)>, ClientError> {
+    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, ClientError> {
         self.store.get_accounts().map_err(|err| err.into())
     }
 
@@ -158,7 +158,7 @@ impl Client {
     pub fn get_account_by_id(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Digest), ClientError> {
+    ) -> Result<(AccountStub, Word), ClientError> {
         self.store
             .get_account_by_id(account_id)
             .map_err(|err| err.into())

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -14,7 +14,9 @@ use miden_node_proto::{
     requests::SyncStateRequest,
     responses::{NullifierUpdate, SyncStateResponse},
 };
-use mock::constants::{AccountSeedType, generate_account_seed, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN};
+use mock::constants::{
+    generate_account_seed, AccountSeedType, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
+};
 use mock::mock::account::mock_account;
 use mock::mock::block;
 use mock::mock::notes::mock_notes;
@@ -209,8 +211,14 @@ pub fn insert_mock_data(client: &mut Client) {
     );
 
     let assembler = TransactionKernel::assembler();
-    let (_account_id, account_seed) = generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
-    let account = mock_account(Some(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN), Felt::ONE, None, &assembler);
+    let (_account_id, account_seed) =
+        generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
+    let account = mock_account(
+        Some(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN),
+        Felt::ONE,
+        None,
+        &assembler,
+    );
     let (_consumed, created_notes) = mock_notes(&assembler, &AssetPreservationStatus::Preserved);
 
     // insert notes into database

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -187,7 +187,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     create_mock_sync_state_request_for_account_and_notes(
         &mut requests,
         transaction_inputs.account().id(),
-        &transaction_inputs.input_notes(),
+        transaction_inputs.input_notes(),
     );
 
     requests

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -14,7 +14,7 @@ use miden_node_proto::{
     requests::SyncStateRequest,
     responses::{NullifierUpdate, SyncStateResponse},
 };
-use mock::constants::{AccountSeedType, generate_account_seed};
+use mock::constants::{AccountSeedType, generate_account_seed, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN};
 use mock::mock::account::mock_account;
 use mock::mock::block;
 use mock::mock::notes::mock_notes;
@@ -209,8 +209,8 @@ pub fn insert_mock_data(client: &mut Client) {
     );
 
     let assembler = TransactionKernel::assembler();
-    let (account_id, account_seed) = generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
-    let account = mock_account(Some(account_id.into()), Felt::ONE, None, &assembler);
+    let (_account_id, account_seed) = generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
+    let account = mock_account(Some(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN), Felt::ONE, None, &assembler);
     let (_consumed, created_notes) = mock_notes(&assembler, &AssetPreservationStatus::Preserved);
 
     // insert notes into database

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -25,6 +25,7 @@ use crate::store::accounts::AuthInfo;
 use miden_tx::TransactionExecutor;
 use objects::accounts::{AccountId, AccountType};
 use objects::assets::FungibleAsset;
+use objects::transaction::InputNote;
 
 /// Mock RPC API
 ///
@@ -75,19 +76,12 @@ impl MockRpcApi {
     }
 }
 
-fn create_mock_sync_state_requests(
+fn create_mock_sync_state_request_for_account_and_notes(
     requests: &mut BTreeMap<SyncStateRequest, SyncStateResponse>,
     account_id: AccountId,
+    recorded_notes: &[InputNote],
 ) {
-    use mock::mock::{
-        account::MockAccountType, notes::AssetPreservationStatus, transaction::mock_inputs,
-    };
-
-    // generate test data
-    let (_account, _, _, recorded_notes) = mock_inputs(
-        MockAccountType::StandardExisting,
-        AssetPreservationStatus::Preserved,
-    );
+    use mock::mock::notes::AssetPreservationStatus;
 
     let accounts = vec![ProtoAccountId {
         id: u64::from(account_id),
@@ -203,111 +197,14 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
         AssetPreservationStatus::Preserved,
     );
 
-    let accounts = vec![ProtoAccountId {
-        id: u64::from(account.id()),
-    }];
-
-    let nullifiers: Vec<u32> = recorded_notes
-        .iter()
-        .map(|input_note| {
-            (input_note.note().nullifier().as_elements()[3].as_int() >> FILTER_ID_SHIFT) as u32
-        })
-        .collect();
-
     // create sync state requests
     let mut requests = BTreeMap::new();
 
-    let assembler = TransactionKernel::assembler();
-    let account = mock_account(None, Felt::ONE, None, &assembler);
-    let (_consumed, created_notes) = mock_notes(&assembler, &AssetPreservationStatus::Preserved);
-
-    // create a state sync request
-    let request = SyncStateRequest {
-        block_num: 0,
-        account_ids: accounts.clone(),
-        note_tags: vec![],
-        nullifiers: nullifiers.clone(),
-    };
-
-    let chain_tip = 10;
-
-    // create a block header for the response
-    let block_header: objects::BlockHeader = block::mock_block_header(8, None, None, &[]);
-
-    // create a state sync response
-    let response = SyncStateResponse {
-        chain_tip,
-        mmr_delta: None,
-        block_path: None,
-        block_header: Some(NodeBlockHeader::from(block_header)),
-        accounts: vec![],
-        notes: vec![NoteSyncRecord {
-            note_index: 0,
-            note_hash: Some(created_notes.first().unwrap().id().into()),
-            sender: account.id().into(),
-            tag: 0u64,
-            num_assets: 2,
-            merkle_path: Some(MerklePath::default()),
-        }],
-        nullifiers: vec![NullifierUpdate {
-            nullifier: Some(
-                recorded_notes
-                    .first()
-                    .unwrap()
-                    .note()
-                    .nullifier()
-                    .inner()
-                    .into(),
-            ),
-            block_num: 7,
-        }],
-    };
-    requests.insert(request, response);
-
-    // SECOND REQUEST
-    // ---------------------------------------------------------------------------------
-
-    // create a state sync request
-    let request = SyncStateRequest {
-        block_num: 8,
-        account_ids: accounts.clone(),
-        note_tags: vec![],
-        nullifiers,
-    };
-
-    // create a block header for the response
-    let block_header: objects::BlockHeader = block::mock_block_header(10, None, None, &[]);
-
-    // create a state sync response
-    let response = SyncStateResponse {
-        chain_tip,
-        mmr_delta: None,
-        block_path: None,
-        block_header: Some(NodeBlockHeader::from(block_header)),
-        accounts: vec![],
-        notes: vec![NoteSyncRecord {
-            note_index: 0,
-            note_hash: Some(created_notes.first().unwrap().id().into()),
-            sender: account.id().into(),
-            tag: 0u64,
-            num_assets: 2,
-            merkle_path: Some(MerklePath::default()),
-        }],
-        nullifiers: vec![NullifierUpdate {
-            nullifier: Some(
-                recorded_notes
-                    .first()
-                    .unwrap()
-                    .note()
-                    .nullifier()
-                    .inner()
-                    .into(),
-            ),
-            block_num: 7,
-        }],
-    };
-
-    requests.insert(request, response);
+    create_mock_sync_state_request_for_account_and_notes(
+        &mut requests,
+        account.id(),
+        &recorded_notes,
+    );
 
     requests
 }
@@ -349,7 +246,15 @@ pub fn insert_mock_data(client: &mut Client) {
         .unwrap();
 
     // insert some sync request
-    create_mock_sync_state_requests(&mut client.rpc_api.sync_state_requests, account_id)
+    let (_account, _, _, recorded_notes) = mock_inputs(
+        MockAccountType::StandardExisting,
+        AssetPreservationStatus::Preserved,
+    );
+    create_mock_sync_state_request_for_account_and_notes(
+        &mut client.rpc_api.sync_state_requests,
+        account_id,
+        &recorded_notes,
+    );
 }
 
 pub async fn create_mock_transaction(client: &mut Client) {

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -3,10 +3,10 @@ use super::Store;
 use crate::errors::StoreError;
 
 use clap::error::Result;
-use crypto::Word;
 use crypto::dsa::rpo_falcon512::KeyPair;
 use crypto::hash::rpo::RpoDigest;
 use crypto::utils::{Deserializable, Serializable};
+use crypto::Word;
 use objects::accounts::AccountStub;
 use objects::assembly::AstSerdeOptions;
 use objects::assets::AssetVault;
@@ -239,17 +239,29 @@ impl Store {
         tx.commit().map_err(StoreError::TransactionError)
     }
 
-    fn insert_account_record(tx: &Transaction<'_>, account: &Account, account_seed: Word) -> Result<(), StoreError> {
+    fn insert_account_record(
+        tx: &Transaction<'_>,
+        account: &Account,
+        account_seed: Word,
+    ) -> Result<(), StoreError> {
         let (id, code_root, storage_root, vault_root, nonce, committed) =
             serialize_account(account)?;
 
-        let account_seed = serde_json::to_string(&account_seed)
-        .map_err(StoreError::InputSerializationError)?;
+        let account_seed =
+            serde_json::to_string(&account_seed).map_err(StoreError::InputSerializationError)?;
 
         const QUERY: &str =  "INSERT INTO accounts (id, code_root, storage_root, vault_root, nonce, committed, account_seed) VALUES (?, ?, ?, ?, ?, ?, ?)";
         tx.execute(
             QUERY,
-            params![id, code_root, storage_root, vault_root, nonce, committed, account_seed],
+            params![
+                id,
+                code_root,
+                storage_root,
+                vault_root,
+                nonce,
+                committed,
+                account_seed
+            ],
         )
         .map(|_| ())
         .map_err(StoreError::QueryError)

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -106,7 +106,7 @@ impl Store {
             .collect::<Result<Vec<AccountId>, _>>()
     }
 
-    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Digest)>, StoreError> {
+    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, StoreError> {
         const QUERY: &str =
             "SELECT id, nonce, vault_root, storage_root, code_root, account_seed FROM accounts";
         self.db
@@ -125,7 +125,7 @@ impl Store {
     pub fn get_account_by_id(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Digest), StoreError> {
+    ) -> Result<(AccountStub, Word), StoreError> {
         let account_id_int: u64 = account_id.into();
         const QUERY: &str =
             "SELECT id, nonce, vault_root, storage_root, code_root, account_seed FROM accounts WHERE id = ?";
@@ -334,7 +334,7 @@ pub(crate) fn parse_accounts_columns(
 /// Parse an account from the provided parts.
 pub(crate) fn parse_accounts(
     serialized_account_parts: SerializedAccountsParts,
-) -> Result<(AccountStub, Digest), StoreError> {
+) -> Result<(AccountStub, Word), StoreError> {
     let (id, nonce, vault_root, storage_root, code_root, account_seed) = serialized_account_parts;
     let account_seed_word: Word =
         Word::read_from_bytes(&account_seed).map_err(StoreError::DataDeserializationError)?;
@@ -349,7 +349,7 @@ pub(crate) fn parse_accounts(
             Digest::try_from(&storage_root).map_err(StoreError::HexParseError)?,
             serde_json::from_str(&code_root).map_err(StoreError::JsonDataDeserializationError)?,
         ),
-        account_seed_word.into(),
+        account_seed_word,
     ))
 }
 

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -92,7 +92,7 @@ impl Store {
                 let account_id_int: u64 = account_id.clone().into();
                 const ACCOUNT_HASH_QUERY: &str = "SELECT hash FROM accounts WHERE id = ?";
 
-                if let Some(Ok(acc_stub)) = tx
+                if let Some(Ok((acc_stub, _acc_seed))) = tx
                     .prepare(ACCOUNT_HASH_QUERY)
                     .map_err(StoreError::QueryError)?
                     .query_map(params![account_id_int as i64], parse_accounts_columns)

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -36,6 +36,7 @@ CREATE TABLE accounts (
     vault_root BLOB NOT NULL,      -- root of the account_vault Merkle tree.
     nonce BIGINT NOT NULL,         -- account nonce.
     committed BOOLEAN NOT NULL,    -- true if recorded, false if not.
+    account_seed BLOB NOT NULL,    -- account seed used to generate the ID.
     PRIMARY KEY (id),
     FOREIGN KEY (code_root) REFERENCES account_code(root),
     FOREIGN KEY (storage_root) REFERENCES account_storage(root),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,10 @@
 // TESTS
 // ================================================================================================
 use crate::{
-    client::{accounts::{AccountStorageMode, AccountTemplate}, Client},
+    client::{
+        accounts::{AccountStorageMode, AccountTemplate},
+        Client,
+    },
     config::{ClientConfig, Endpoint},
     store::{
         accounts::AuthInfo,
@@ -21,7 +24,10 @@ use mock::{
         transaction::mock_inputs,
     },
 };
-use objects::{accounts::{AccountId, AccountStub}, assets::TokenSymbol};
+use objects::{
+    accounts::{AccountId, AccountStub},
+    assets::TokenSymbol,
+};
 #[tokio::test]
 async fn test_input_notes_round_trip() {
     // generate test store path

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,11 +13,14 @@ use crate::{
 use crypto::dsa::rpo_falcon512::KeyPair;
 use crypto::{Felt, FieldElement};
 use miden_lib::transaction::TransactionKernel;
-use mock::{mock::{
-    account::{self, MockAccountType},
-    notes::AssetPreservationStatus,
-    transaction::mock_inputs,
-}, constants::{AccountSeedType, generate_account_seed}};
+use mock::{
+    constants::{generate_account_seed, AccountSeedType},
+    mock::{
+        account::{self, MockAccountType},
+        notes::AssetPreservationStatus,
+        transaction::mock_inputs,
+    },
+};
 use objects::accounts::{AccountId, AccountStub};
 #[tokio::test]
 async fn test_input_notes_round_trip() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -149,7 +149,7 @@ async fn test_get_account_by_id() {
         .unwrap();
 
     // Retrieving an existing account should succeed
-    let acc_from_db = match client.get_account_by_id(account.id()) {
+    let (acc_from_db, _account_seed) = match client.get_account_by_id(account.id()) {
         Ok(account) => account,
         Err(err) => panic!("Error retrieving account: {}", err),
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,11 +24,11 @@ use mock::{
         transaction::mock_inputs,
     },
 };
+use objects::transaction::InputNotes;
 use objects::{
     accounts::{AccountId, AccountStub},
     assets::TokenSymbol,
 };
-use objects::transaction::InputNotes;
 
 #[tokio::test]
 async fn test_input_notes_round_trip() {


### PR DESCRIPTION
When creating an account, a seed is generated which is after used to create the account id. We were currently not storing it. For this PR we:

- Add a non nullable field to the accounts table called account_seed
- When creating new accounts (any kind of account), we also store the account seed
- `new_account` function from client now also returns the seed
- For the account show and account list, I made it so the store returns both the account and the seed and all data is displayed in the table. To show it I print the seed (a Word) as a single hexstring
- On places where we used `let account = mock_account(None, Felt::ONE, None, &assembler);` I changed it so we first generate the seed and account with `mock::constants::generate_account_seed` and then we pass it to `mock_account`
  - This made the `test_sync_state` test fail because before it was always creating an account with it's id being the one in `mock::constants::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN`, which is the one used to populate the sync requests mock at `generate_sync_state_mock_requests` when the rpc client is created. I added a function named `create_mock_sync_state_request_for_account_and_notes` to populate the mocked requests after the rpc_client was already created ([959a99a](https://github.com/lambdaclass/miden-client/pull/9/commits/959a99a08f9a486c3ffbd2a7312f4f970ab92302) and [c65af9a](https://github.com/lambdaclass/miden-client/pull/9/commits/c65af9ac8806045b022dd22e76b33b1e002a8a68))
