### PR TITLE
remove unwraps on options for sync rpc response

### DIFF
--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -70,7 +70,7 @@ impl Client {
                 .block_header
                 .as_ref()
                 .ok_or(ClientError::RpcExpectedFieldMissingFailure(
-                    format!("Expected block header for response: {:?}", &response).to_string(),
+                    format!("Expected block header for response: {:?}", &response),
                 ))?;
         let incoming_block_header: BlockHeader = incoming_block_header
             .try_into()
@@ -84,7 +84,7 @@ impl Client {
             .map(|x| {
                 x.nullifier
                     .ok_or(ClientError::RpcExpectedFieldMissingFailure(
-                        format!("Expected nullifier for response {:?}", &response).to_string(),
+                        format!("Expected nullifier for response {:?}", &response),
                     ))
             })
             .collect::<Result<Vec<_>, ClientError>>()?;

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -65,7 +65,7 @@ impl Client {
         let response = self
             .sync_state_request(block_num, &account_ids, &note_tags, &nullifiers)
             .await?;
-        let incoming_block_header = response.block_header.ok_or(ClientError::RpcExpectedFieldMissingFailure("Expected block header".to_string()))?;
+        let incoming_block_header = response.block_header.as_ref().ok_or(ClientError::RpcExpectedFieldMissingFailure(format!("Expected block header for response: {:?}", &response).to_string()))?;
         let incoming_block_header: BlockHeader = incoming_block_header
             .try_into()
             .map_err(ClientError::RpcTypeConversionFailure)?;
@@ -73,9 +73,10 @@ impl Client {
         // Handle any missing nullifiers
         let response_nullifiers = response
             .nullifiers
+            .clone()
             .into_iter()
             .map(|x| {
-                x.nullifier.ok_or(ClientError::RpcExpectedFieldMissingFailure("Expected nullifier".to_string()))
+                x.nullifier.ok_or(ClientError::RpcExpectedFieldMissingFailure(format!("Expected nullifier for response {:?}", &response).to_string()))
             })
             .collect::<Result<Vec<_>, ClientError>>()?;
 

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -69,9 +69,10 @@ impl Client {
             response
                 .block_header
                 .as_ref()
-                .ok_or(ClientError::RpcExpectedFieldMissingFailure(
-                    format!("Expected block header for response: {:?}", &response),
-                ))?;
+                .ok_or(ClientError::RpcExpectedFieldMissingFailure(format!(
+                    "Expected block header for response: {:?}",
+                    &response
+                )))?;
         let incoming_block_header: BlockHeader = incoming_block_header
             .try_into()
             .map_err(ClientError::RpcTypeConversionFailure)?;
@@ -83,9 +84,10 @@ impl Client {
             .into_iter()
             .map(|x| {
                 x.nullifier
-                    .ok_or(ClientError::RpcExpectedFieldMissingFailure(
-                        format!("Expected nullifier for response {:?}", &response),
-                    ))
+                    .ok_or(ClientError::RpcExpectedFieldMissingFailure(format!(
+                        "Expected nullifier for response {:?}",
+                        &response
+                    )))
             })
             .collect::<Result<Vec<_>, ClientError>>()?;
 

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -65,7 +65,13 @@ impl Client {
         let response = self
             .sync_state_request(block_num, &account_ids, &note_tags, &nullifiers)
             .await?;
-        let incoming_block_header = response.block_header.as_ref().ok_or(ClientError::RpcExpectedFieldMissingFailure(format!("Expected block header for response: {:?}", &response).to_string()))?;
+        let incoming_block_header =
+            response
+                .block_header
+                .as_ref()
+                .ok_or(ClientError::RpcExpectedFieldMissingFailure(
+                    format!("Expected block header for response: {:?}", &response).to_string(),
+                ))?;
         let incoming_block_header: BlockHeader = incoming_block_header
             .try_into()
             .map_err(ClientError::RpcTypeConversionFailure)?;
@@ -76,7 +82,10 @@ impl Client {
             .clone()
             .into_iter()
             .map(|x| {
-                x.nullifier.ok_or(ClientError::RpcExpectedFieldMissingFailure(format!("Expected nullifier for response {:?}", &response).to_string()))
+                x.nullifier
+                    .ok_or(ClientError::RpcExpectedFieldMissingFailure(
+                        format!("Expected nullifier for response {:?}", &response).to_string(),
+                    ))
             })
             .collect::<Result<Vec<_>, ClientError>>()?;
 

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -39,7 +39,7 @@ pub struct PaymentTransactionData {
 }
 
 impl PaymentTransactionData {
-    pub const fn new(
+    pub fn new(
         asset: Asset,
         sender_account_id: AccountId,
         target_account_id: AccountId,

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -39,7 +39,7 @@ pub struct PaymentTransactionData {
 }
 
 impl PaymentTransactionData {
-    pub fn new(
+    pub const fn new(
         asset: Asset,
         sender_account_id: AccountId,
         target_account_id: AccountId,
@@ -157,11 +157,11 @@ impl Client {
                 None,
             );
             let data_store: MockDataStore = MockDataStore::with_existing(
-                Some(target_account.clone()),
-                Some(vec![note.clone()]),
+                Some(target_account),
+                Some(vec![note]),
             );
 
-            self.set_data_store(data_store.clone());
+            self.set_data_store(data_store);
         }
 
         self.tx_executor
@@ -185,7 +185,7 @@ impl Client {
         let tx_script_target = self
             .tx_executor
             .compile_tx_script(
-                tx_script_code.clone(),
+                tx_script_code,
                 vec![/*(target_pub_key, target_sk_pk_felt)*/],
                 vec![],
             )
@@ -198,7 +198,7 @@ impl Client {
                 target_account_id,
                 block_ref,
                 &note_origins,
-                Some(tx_script_target.clone()),
+                Some(tx_script_target),
             )
             .map_err(ClientError::TransactionExecutionError)?;
 

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -156,10 +156,8 @@ impl Client {
                 target_pub_key,
                 None,
             );
-            let data_store: MockDataStore = MockDataStore::with_existing(
-                Some(target_account),
-                Some(vec![note]),
-            );
+            let data_store: MockDataStore =
+                MockDataStore::with_existing(Some(target_account), Some(vec![note]));
 
             self.set_data_store(data_store);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct ClientConfig {
 
 impl ClientConfig {
     /// Returns a new instance of [ClientConfig] with the specified store path and node endpoint.
-    pub fn new(store_path: String, node_endpoint: Endpoint) -> Self {
+    pub const fn new(store_path: String, node_endpoint: Endpoint) -> Self {
         Self {
             store_path,
             node_endpoint,
@@ -57,7 +57,7 @@ pub struct Endpoint {
 
 impl Endpoint {
     /// Returns a new instance of [Endpoint] with the specified protocol, host, and port.
-    pub fn new(protocol: String, host: String, port: u16) -> Self {
+    pub const fn new(protocol: String, host: String, port: u16) -> Self {
         Self {
             protocol,
             host,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,7 @@ pub enum ClientError {
     StoreError(StoreError),
     TransactionExecutionError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
+    RpcExpectedFieldMissingFailure(String),
 }
 
 impl fmt::Display for ClientError {
@@ -42,6 +43,9 @@ impl fmt::Display for ClientError {
             }
             ClientError::TransactionProvingError(err) => {
                 write!(f, "transaction prover error: {err}")
+            }
+            ClientError::RpcExpectedFieldMissingFailure(err) => {
+                write!(f, "rpc api error: {err}")
             }
         }
     }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -153,7 +153,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     // create a state sync request
     let request = SyncStateRequest {
         block_num: 8,
-        account_ids: accounts.clone(),
+        account_ids: accounts,
         note_tags: vec![],
         nullifiers,
     };

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -48,7 +48,7 @@ const RPO_FALCON512_AUTH: u8 = 0;
 
 impl AuthInfo {
     /// Returns byte identifier of specific AuthInfo
-    fn type_byte(&self) -> u8 {
+    const fn type_byte(&self) -> u8 {
         match self {
             AuthInfo::RpoFalcon512(_) => RPO_FALCON512_AUTH,
         }

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -119,7 +119,7 @@ pub fn get_account_with_default_account_code(
     let account_code_ast = ModuleAst::parse(account_code_src).unwrap();
     let account_assembler = TransactionKernel::assembler();
 
-    let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
+    let account_code = AccountCode::new(account_code_ast, &account_assembler).unwrap();
     let account_storage = AccountStorage::new(vec![(
         0,
         (StorageSlotType::Value { value_arity: 0 }, public_key),
@@ -152,7 +152,7 @@ pub fn get_note_with_fungible_asset_and_script(
     let sender_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
 
     Note::new(
-        note_script.clone(),
+        note_script,
         &[],
         &[fungible_asset.into()],
         SERIAL_NUM,

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -75,13 +75,13 @@ pub struct InputNoteRecord {
 }
 
 impl InputNoteRecord {
-    pub const fn new(note: Note, inclusion_proof: Option<NoteInclusionProof>) -> InputNoteRecord {
+    pub fn new(note: Note, inclusion_proof: Option<NoteInclusionProof>) -> InputNoteRecord {
         InputNoteRecord {
             note,
             inclusion_proof,
         }
     }
-    pub const fn note(&self) -> &Note {
+    pub fn note(&self) -> &Note {
         &self.note
     }
 
@@ -89,7 +89,7 @@ impl InputNoteRecord {
         self.note.id()
     }
 
-    pub const fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
+    pub fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
         self.inclusion_proof.as_ref()
     }
 }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -75,13 +75,13 @@ pub struct InputNoteRecord {
 }
 
 impl InputNoteRecord {
-    pub fn new(note: Note, inclusion_proof: Option<NoteInclusionProof>) -> InputNoteRecord {
+    pub const fn new(note: Note, inclusion_proof: Option<NoteInclusionProof>) -> InputNoteRecord {
         InputNoteRecord {
             note,
             inclusion_proof,
         }
     }
-    pub fn note(&self) -> &Note {
+    pub const fn note(&self) -> &Note {
         &self.note
     }
 
@@ -89,7 +89,7 @@ impl InputNoteRecord {
         self.note.id()
     }
 
-    pub fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
+    pub  const fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
         self.inclusion_proof.as_ref()
     }
 }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -89,7 +89,7 @@ impl InputNoteRecord {
         self.note.id()
     }
 
-    pub  const fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
+    pub const fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
         self.inclusion_proof.as_ref()
     }
 }


### PR DESCRIPTION
addresses [#51](https://github.com/0xPolygonMiden/miden-client/issues/51) from forked repo

Note: on [e2b7bd5](https://github.com/lambdaclass/miden-client/pull/10/commits/e2b7bd5432df9ee63f6895d15d21e6ec5f86d6e5) I used clippy with:

```bash
cargo clippy -- -D clippy::nursery -D clippy::all -D clippy::complexity -A clippy::use_self
```

and found out:

- a few functions that could be turned into const functions
- a few redundant clones and to_string