### PR TITLE
Fix `get_account_ids`

### DIFF
--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -95,15 +95,12 @@ impl Store {
         self.db
             .prepare(QUERY)
             .map_err(StoreError::QueryError)?
-            .query_map([], |row| {
-                let row: i64 = row.get(0)?;
-                Ok(row)
-            })
+            .query_map([], |row| row.get(0))
             .expect("no binding parameters used in query")
             .map(|result| {
                 result
                     .map_err(StoreError::ColumnParsingError)
-                    .map(|id: i64| AccountId::try_from(id as u64).expect("account id is not valid"))
+                    .map(|id: i64| AccountId::try_from(id as u64).expect("account id is valid"))
             })
             .collect::<Result<Vec<AccountId>, _>>()
     }

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -97,13 +97,13 @@ impl Store {
             .map_err(StoreError::QueryError)?
             .query_map([], |row| {
                 let row : i64 = row.get(0)?;
-                Ok(row as u64)
+                Ok(row)
             })
             .expect("no binding parameters used in query")
             .map(|result| {
                 result
                     .map_err(StoreError::ColumnParsingError)
-                    .map(|id: u64| AccountId::try_from(id).expect("account id is not valid"))
+                    .map(|id: i64| AccountId::try_from(id as u64).expect("account id is not valid"))
             })
             .collect::<Result<Vec<AccountId>, _>>()
     }

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -96,7 +96,7 @@ impl Store {
             .prepare(QUERY)
             .map_err(StoreError::QueryError)?
             .query_map([], |row| {
-                let row : i64 = row.get(0)?;
+                let row: i64 = row.get(0)?;
                 Ok(row)
             })
             .expect("no binding parameters used in query")

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -95,12 +95,15 @@ impl Store {
         self.db
             .prepare(QUERY)
             .map_err(StoreError::QueryError)?
-            .query_map([], |row| row.get(0))
+            .query_map([], |row| {
+                let row : i64 = row.get(0)?;
+                Ok(row as u64)
+            })
             .expect("no binding parameters used in query")
             .map(|result| {
                 result
                     .map_err(StoreError::ColumnParsingError)
-                    .map(|id: u64| AccountId::try_from(id).expect("account id is valid"))
+                    .map(|id: u64| AccountId::try_from(id).expect("account id is not valid"))
             })
             .collect::<Result<Vec<AccountId>, _>>()
     }


### PR DESCRIPTION
# Motivation

When testing with the cli, I found an error when running:

```bash
cargo run --release --features testing -- sync-state sync-state

store error: failed to parse data retrieved from the database: Integer -9151043079678472443 out of range at index 0
```

# Changes

- read an i64 from rusqlite's `Row` and cast it to u64 afterwards (I saw this was being done for other ids)

# Steps to reproduce

It might take a few tries because it will depend on the generated faucet id. For each try do:

```bash
rm target/release/store.sqlite3
cargo run --release --features testing -- mock-data
cargo run --release --features testing -- account new fungible-faucet -t TEST -d 10 -m 10000
# It should raise here
cargo run --release --features testing -- sync-state sync-state
```
