### PR TITLE
chore: Make non-default option lowercase when asking for confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Updated Web Client README and Documentation (#808).
 * [BREAKING] Removed `script_roots` mod in favor of `WellKnownNote` (#834).
+* Underscore non-default options when prompting for transaction confirmation (#TDB)
 
 ## 0.8.1 (2025-03-28)
 

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -351,7 +351,7 @@ async fn execute_transaction(
     print_transaction_details(&transaction_execution_result)?;
     if !force {
         println!(
-            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (Y/N)"
+            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)"
         );
         let mut proceed_str: String = String::new();
         io::stdin().read_line(&mut proceed_str).expect("Should read line");

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -263,7 +263,7 @@ TX Summary:
 
 ...
 
-Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (Y/N)
+Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)
 ```
 
 This confirmation can be skipped in non-interactive environments by providing the `--force` flag (`miden send --force ...`):


### PR DESCRIPTION
Currently when prompting for transaction confirmation, both options are in uppercase. It's customary for the default option to be in uppercase, whilst the non-default option(s) to be in lowercase.

This PR underscores the "yes" option to indicate that it's not the default. 