### PR TITLE
feat(web-client): Do not assume testnet for bech32 AccountID encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.0 (TBD)
 
 - [BREAKING] Incremented MSRV to 1.88.
+- [BREAKING] `toBech32` AccountID method now expects a parameter to specify the network id.
 
 ## 0.10.0 (2025-07-12)
 

--- a/crates/web-client/src/models/account_id.rs
+++ b/crates/web-client/src/models/account_id.rs
@@ -42,11 +42,11 @@ impl AccountId {
         self.0.to_string()
     }
 
-    #[wasm_bindgen(js_name = "toBech32")]
     /// Will turn the Account ID into its bech32 string representation.
     /// To avoid a potential wrongful encoding, this function will
     /// expect only ids for either mainnet, testnet or devnet.
     /// To use a custom bech32 prefix, use `Self::to_bech_32_custom`.
+    #[wasm_bindgen(js_name = "toBech32")]
     pub fn to_bech32(&self, network_id: &str) -> Result<String, String> {
         match NetworkId::from_str(network_id) {
             Ok(NetworkId::Custom(_)) => {

--- a/crates/web-client/src/models/account_id.rs
+++ b/crates/web-client/src/models/account_id.rs
@@ -61,9 +61,12 @@ impl AccountId {
     /// Turn this Account ID into its bech32 string representation.
     /// This method accepts a custom network id.
     pub fn to_bech32_custom(&self, network_id: &str) -> Result<String, String> {
-        NetworkId::from_str(network_id)
-            .map(|valid_net_id| self.0.to_bech32(valid_net_id))
-            .map_err(|err| format!("Given network id is not valid: {err}"))
+        let network_id = NetworkId::from_str(network_id)
+            .map_err(|err| format!("Given network id is not valid: {err}"))?;
+        match network_id {
+            NetworkId::Custom(_) => Ok(self.0.to_bech32(network_id)),
+            _ => Err("Expected a custom network id".to_owned()),
+        }
     }
 
     pub fn prefix(&self) -> Felt {

--- a/crates/web-client/src/models/account_id.rs
+++ b/crates/web-client/src/models/account_id.rs
@@ -57,9 +57,9 @@ impl AccountId {
         }
     }
 
-    #[wasm_bindgen(js_name = "toBech32Custom")]
     /// Turn this Account ID into its bech32 string representation.
     /// This method accepts a custom network id.
+    #[wasm_bindgen(js_name = "toBech32Custom")]
     pub fn to_bech32_custom(&self, network_id: &str) -> Result<String, String> {
         let network_id = NetworkId::from_str(network_id)
             .map_err(|err| format!("Given network id is not valid: {err}"))?;

--- a/crates/web-client/src/models/account_id.rs
+++ b/crates/web-client/src/models/account_id.rs
@@ -44,7 +44,7 @@ impl AccountId {
 
     /// Will turn the Account ID into its bech32 string representation.
     /// To avoid a potential wrongful encoding, this function will
-    /// expect only ids for either mainnet, testnet or devnet.
+    /// expect only IDs for either mainnet ("mm"), testnet ("mtst") or devnet ("mdev").
     /// To use a custom bech32 prefix, use `Self::to_bech_32_custom`.
     #[wasm_bindgen(js_name = "toBech32")]
     pub fn to_bech32(&self, network_id: &str) -> Result<String, String> {
@@ -58,7 +58,7 @@ impl AccountId {
     }
 
     /// Turn this Account ID into its bech32 string representation.
-    /// This method accepts a custom network id.
+    /// This method accepts a custom network ID.
     #[wasm_bindgen(js_name = "toBech32Custom")]
     pub fn to_bech32_custom(&self, network_id: &str) -> Result<String, String> {
         let network_id = NetworkId::from_str(network_id)

--- a/docs/src/web-client/api/classes/AccountId.md
+++ b/docs/src/web-client/api/classes/AccountId.md
@@ -60,7 +60,37 @@
 
 ### toBech32()
 
-> **toBech32**(): `string`
+> **toBech32**(`network_id`): `string`
+
+Will turn the Account ID into its bech32 string representation.
+To avoid a potential wrongful encoding, this function will
+expect only ids for either mainnet, testnet or devnet.
+To use a custom bech32 prefix, use `Self::to_bech_32_custom`.
+
+#### Parameters
+
+##### network\_id
+
+`string`
+
+#### Returns
+
+`string`
+
+***
+
+### toBech32Custom()
+
+> **toBech32Custom**(`network_id`): `string`
+
+Turn this Account ID into its bech32 string representation.
+This method accepts a custom network id.
+
+#### Parameters
+
+##### network\_id
+
+`string`
 
 #### Returns
 

--- a/docs/src/web-client/api/classes/AccountId.md
+++ b/docs/src/web-client/api/classes/AccountId.md
@@ -64,7 +64,7 @@
 
 Will turn the Account ID into its bech32 string representation.
 To avoid a potential wrongful encoding, this function will
-expect only ids for either mainnet, testnet or devnet.
+expect only IDs for either mainnet ("mm"), testnet ("mtst") or devnet ("mdev").
 To use a custom bech32 prefix, use `Self::to_bech_32_custom`.
 
 #### Parameters
@@ -84,7 +84,7 @@ To use a custom bech32 prefix, use `Self::to_bech_32_custom`.
 > **toBech32Custom**(`network_id`): `string`
 
 Turn this Account ID into its bech32 string representation.
-This method accepts a custom network id.
+This method accepts a custom network ID.
 
 #### Parameters
 


### PR DESCRIPTION
## Description 
This PR updates the function `AccountID::to_bech32` to accept a new parameter for the network id, 
instead of having testnet hardcoded

[Closes issue 1019](https://github.com/0xMiden/miden-client/issues/1019)