### PR TITLE
chore: add verbatim_doc_comment in ExecCmd::inputs_path

### DIFF
--- a/bin/miden-cli/src/commands/exec.rs
+++ b/bin/miden-cli/src/commands/exec.rs
@@ -38,6 +38,7 @@ pub struct ExecCmd {
     ///        { key = "0x0000000000000000000000000000000000000000000000000000000000000000" , values = ["1", "2"]},
     ///    ]
     #[arg(long, short)]
+    #[clap(verbatim_doc_comment)]
     inputs_path: Option<String>,
 
     /// Print the output stack grouped into words


### PR DESCRIPTION
Clap ignores the newlines from `ExecCMD::input_paths`'s doc-comment. This hinders the comments' readability. 

This PR adds the `#[clap(verbatim_doc_comment)]` in order for it to follow the formatting.

For reference, here's the before and after:
Before:
```
$~ miden-client exec --help
Execute the specified program against the specified account
(...)

  -i, --inputs-path <INPUTS_PATH>
          Path to the inputs file. This file will be used as inputs to the VM's advice map.
          
          The file should contain a TOML array of inline tables, where each table has two fields: - `key`: a 256-bit hexadecimal string representing a word to be used as a key for the input entry. The hexadecimal value must be prefixed with 0x. - `values`: an array of 64-bit unsigned integers representing field elements to be used as values for the input entry. Each integer must be written as a separate string, within double quotes.
          
          The input file should contain a TOML table called `inputs`, as in the following example: inputs = [ { key = "0x0000001000000000000000000000000000000000000000000000000000000000", values = ["13", "9"]}, { key = "0x0000000000000000000000000000000000000000000000000000000000000000" , values = ["1", "2"]}, ]

(...)
```
After:
```
(...)
  -i, --inputs-path <INPUTS_PATH>
          Path to the inputs file. This file will be used as inputs to the VM's advice map.
          
          The file should contain a TOML array of inline tables, where each table has two fields:
          - `key`: a 256-bit hexadecimal string representing a word to be used as a key for the input
            entry. The hexadecimal value must be prefixed with 0x.
          - `values`: an array of 64-bit unsigned integers representing field elements to be used as
            values for the input entry. Each integer must be written as a separate string, within
            double quotes.
          
          The input file should contain a TOML table called `inputs`, as in the following example:
             inputs = [
                 { key = "0x0000001000000000000000000000000000000000000000000000000000000000", values = ["13", "9"]},
                 { key = "0x0000000000000000000000000000000000000000000000000000000000000000" , values = ["1", "2"]},
             ]
(...)
```