### PR TITLE
feat: create account from Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Bumped web-client version in package.json after merging main into next.
 * Added support for getting specific vault and storage elements from `Store` along with their proofs ([#1164](https://github.com/0xMiden/miden-client/pull/1164)).
 * Modified the RPC client to avoid reconnection when setting commitment header ([#1166](https://github.com/0xMiden/miden-client/pull/1166)).
+* Added account creation from miden packages (#TBD).
 
 ## 0.11.3 (2025-09-08)
 

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -209,7 +209,7 @@ impl NewAccountCmd {
 
 type ComponentPath = PathBuf;
 type PackagePath = PathBuf;
-/// Reads component templates from the given file paths.
+/// Reads component templates and [[miden_core::vm::Package]]s from the given file paths.
 fn load_component_templates(
     component_paths: &[ComponentPath],
     package_paths: &[PackagePath],

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -209,7 +210,7 @@ impl NewAccountCmd {
 
 type ComponentPath = PathBuf;
 type PackagePath = PathBuf;
-/// Reads component templates and [[miden_core::vm::Package]]s from the given file paths.
+/// Reads component templates and [[`miden_core::vm::Package`]]s from the given file paths.
 fn load_component_templates(
     component_paths: &[ComponentPath],
     package_paths: &[PackagePath],
@@ -226,7 +227,9 @@ fn load_component_templates(
                 Ok(path.with_extension(COMPONENT_TEMPLATE_EXTENSION))
             },
             Some(extension) => {
-                if extension != OsStr::new(COMPONENT_TEMPLATE_EXTENSION) {
+                if extension == OsStr::new(COMPONENT_TEMPLATE_EXTENSION) {
+                    Ok(path.clone())
+                } else {
                     let error = std::io::Error::new(
                         std::io::ErrorKind::InvalidFilename,
                         format!(
@@ -243,8 +246,6 @@ fn load_component_templates(
                             path.display()
                         ),
                     ))
-                } else {
-                    Ok(path.clone())
                 }
             },
         }?;
@@ -273,13 +274,15 @@ fn load_component_templates(
         // leave the passed in path as is; since it probably is a full path.
         // This is the case with cargo-miden, which displays the full path to
         // stdout after compilation finishes.
-        let file_name = match path.extension() {
+        let path = match path.extension() {
             None => {
                 let path = path.with_extension(MIDEN_PACKAGE_EXTENSION);
                 Ok(packages_dir.join(path))
             },
             Some(extension) => {
-                if extension != OsStr::new(MIDEN_PACKAGE_EXTENSION) {
+                if extension == OsStr::new(MIDEN_PACKAGE_EXTENSION) {
+                    Ok(path.clone())
+                } else {
                     let error = std::io::Error::new(
                         std::io::ErrorKind::InvalidFilename,
                         format!(
@@ -293,8 +296,6 @@ fn load_component_templates(
                         Box::new(error),
                         format!("failed to read Package from {}", path.display()),
                     ))
-                } else {
-                    Ok(path.clone())
                 }
             },
         }?;

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -5,26 +5,24 @@ use std::path::PathBuf;
 use std::vec;
 
 use clap::{Parser, ValueEnum};
-use miden_client::Client;
 use miden_client::account::component::{COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION};
 use miden_client::account::{Account, AccountBuilder, AccountStorageMode, AccountType};
 use miden_client::auth::{AuthSecretKey, TransactionAuthenticator};
 use miden_client::crypto::SecretKey;
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_client::utils::Deserializable;
+use miden_client::Client;
 use miden_lib::account::auth::AuthRpoFalcon512;
 use miden_objects::account::{
-    AccountComponent,
-    AccountComponentTemplate,
-    InitStorageData,
-    StorageValueName,
+    AccountComponent, AccountComponentTemplate, InitStorageData, StorageValueName,
 };
+use miden_objects::vm::Package;
 use rand::RngCore;
 use tracing::debug;
 
 use crate::commands::account::maybe_set_default_account;
 use crate::errors::CliError;
-use crate::{CliKeyStore, client_binary_name, load_config_file};
+use crate::{client_binary_name, load_config_file, CliKeyStore};
 
 // CLI TYPES
 // ================================================================================================
@@ -205,6 +203,7 @@ impl NewAccountCmd {
 fn load_component_templates(paths: &[PathBuf]) -> Result<Vec<AccountComponentTemplate>, CliError> {
     let (cli_config, _) = load_config_file()?;
     let components_base_dir = &cli_config.component_template_directory;
+    let packages_dir = &cli_config.package_directory;
     let mut templates = Vec::new();
 
     let possible_extensions = [COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION];
@@ -229,13 +228,54 @@ fn load_component_templates(paths: &[PathBuf]) -> Result<Vec<AccountComponentTem
             )
         })?;
 
-        let bytes = fs::read(components_base_dir.join(found_file))?;
-        let template = AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
-            CliError::AccountComponentError(
-                Box::new(e),
-                "failed to read account component template".into(),
-            )
-        })?;
+        std::dbg!("A PUNTO DE LEER");
+        std::dbg!("DONE");
+        let template = match found_file.extension().and_then(|ext| ext.to_str()) {
+            Some(COMPONENT_TEMPLATE_EXTENSION) => {
+                let bytes = fs::read(components_base_dir.join(&found_file))?;
+                AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
+                    CliError::AccountComponentError(
+                        Box::new(e),
+                        format!(
+                            "failed to read account component template from {}",
+                            found_file.display()
+                        ),
+                    )
+                })?
+            },
+            Some(MIDEN_PACKAGE_EXTENSION) => {
+                let bytes = fs::read(packages_dir.join(&found_file))?;
+                let package = Package::read_from_bytes(&bytes).map_err(|e| {
+                    CliError::AccountComponentError(
+                        Box::new(e),
+                        format!(
+                            "failed to read account component template from Package in {}",
+                            found_file.display()
+                        ),
+                    )
+                })?;
+
+                AccountComponentTemplate::try_from(package).map_err(|e| {
+                    CliError::AccountComponentError(
+                        Box::new(e),
+                        format!(
+                            "failed to read account component template from Package in {}",
+                            found_file.display()
+                        ),
+                    )
+                })?
+            },
+            Some(unknown_extension) => {
+                todo!();
+                // let a = 1;
+                // Err(CliError::AccountComponentError((), format!()))
+            },
+            None => {
+                // This case should never occur
+                todo!();
+            },
+        };
+
         templates.push(template);
     }
     Ok(templates)

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -219,12 +219,26 @@ fn load_component_templates(
 
     let components_base_dir = &cli_config.component_template_directory;
     for path in component_paths {
-        let path = if path.extension().is_none() {
-            path.with_extension(COMPONENT_TEMPLATE_EXTENSION)
-        } else {
-            path.clone()
-        };
-        let path = components_base_dir.join(&path);
+        let file_name = match path.extension() {
+            None => Ok(path.with_extension(COMPONENT_TEMPLATE_EXTENSION)),
+            Some(extension) => {
+                if extension != OsStr::new(COMPONENT_TEMPLATE_EXTENSION) {
+                    Err(CliError::AccountComponentError(
+                        Box::new(std::io::Error::new(
+                            std::io::ErrorKind::InvalidFilename,
+                            format!("{} has an invalid file extension: {}. Expected: {COMPONENT_TEMPLATE_EXTENSION}", path.display(), extension.display()),
+                        )),
+                        format!(
+                            "failed to read account component template from {}",
+                            path.display()
+                        ),
+                    ))
+                } else {
+                    Ok(path.clone())
+                }
+            },
+        }?;
+        let path = components_base_dir.join(&file_name);
 
         let bytes = fs::read(&path).map_err(|e| {
             CliError::AccountComponentError(
@@ -249,12 +263,28 @@ fn load_component_templates(
         // leave the passed in path as is; since it probably is a full path.
         // This is the case with cargo-miden, which displays the full path to
         // stdout after compilation finishes.
-        let path = if path.extension().is_none() {
-            let path = path.with_extension(MIDEN_PACKAGE_EXTENSION);
-            packages_dir.join(&path)
-        } else {
-            path.clone()
-        };
+        let file_name = match path.extension() {
+            None => {
+                let path = path.with_extension(MIDEN_PACKAGE_EXTENSION);
+                Ok(packages_dir.join(path))
+            },
+            Some(extension) => {
+                if extension != OsStr::new(MIDEN_PACKAGE_EXTENSION) {
+                    Err(CliError::AccountComponentError(
+                        Box::new(std::io::Error::new(
+                            std::io::ErrorKind::InvalidFilename,
+                            format!("{} has an invalid file extension: {}. Expected: {MIDEN_PACKAGE_EXTENSION}", path.display(), extension.display()),
+                        )),
+                        format!(
+                            "failed to read Package from {}",
+                            path.display()
+                        ),
+                    ))
+                } else {
+                    Ok(path.clone())
+                }
+            },
+        }?;
 
         let bytes = fs::read(&path).map_err(|e| {
             CliError::AccountComponentError(

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -5,16 +5,19 @@ use std::path::PathBuf;
 use std::vec;
 
 use clap::{Parser, ValueEnum};
+use miden_client::Client;
 use miden_client::account::component::{COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION};
 use miden_client::account::{Account, AccountBuilder, AccountStorageMode, AccountType};
 use miden_client::auth::{AuthSecretKey, TransactionAuthenticator};
 use miden_client::crypto::SecretKey;
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_client::utils::Deserializable;
-use miden_client::Client;
 use miden_lib::account::auth::AuthRpoFalcon512;
 use miden_objects::account::{
-    AccountComponent, AccountComponentTemplate, InitStorageData, StorageValueName,
+    AccountComponent,
+    AccountComponentTemplate,
+    InitStorageData,
+    StorageValueName,
 };
 use miden_objects::vm::Package;
 use rand::RngCore;
@@ -22,7 +25,7 @@ use tracing::debug;
 
 use crate::commands::account::maybe_set_default_account;
 use crate::errors::CliError;
-use crate::{client_binary_name, load_config_file, CliKeyStore};
+use crate::{CliKeyStore, client_binary_name, load_config_file};
 
 // CLI TYPES
 // ================================================================================================

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -116,6 +116,7 @@ impl NewWalletCmd {
             account_type,
             self.storage_mode.into(),
             &component_template_paths,
+            &[],
             self.init_storage_data_path.clone(),
             self.deploy,
         )
@@ -155,6 +156,10 @@ pub struct NewAccountCmd {
     /// lease one component template is required.
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
+    /// List of [[miden_core::vm::Package]]s from where a component template is going to be extracted.
+    /// lease one component template is required.
+    #[arg(short, long)]
+    pub packages: Vec<PathBuf>,
     /// Optional file path to a TOML file containing a list of key/values used for initializing
     /// storage. Each of these keys should map to the templated storage values within the passed
     /// list of component templates. The user will be prompted to provide values for any keys not
@@ -179,6 +184,7 @@ impl NewAccountCmd {
             self.account_type.into(),
             self.storage_mode.into(),
             &self.component_templates,
+            &self.packages,
             self.init_storage_data_path.clone(),
             self.deploy,
         )
@@ -198,86 +204,74 @@ impl NewAccountCmd {
 // HELPERS
 // ================================================================================================
 
+type ComponentPath = PathBuf;
+type PackagePath = PathBuf;
 /// Reads component templates from the given file paths.
 // TODO: IO errors should have more context
-fn load_component_templates(paths: &[PathBuf]) -> Result<Vec<AccountComponentTemplate>, CliError> {
+fn load_component_templates(
+    component_paths: &[ComponentPath],
+    package_paths: &[PackagePath],
+) -> Result<Vec<AccountComponentTemplate>, CliError> {
     let (cli_config, _) = load_config_file()?;
     let components_base_dir = &cli_config.component_template_directory;
     let packages_dir = &cli_config.package_directory;
     let mut templates = Vec::new();
 
     let possible_extensions = [COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION];
-    for path in paths {
-        // If the user did not specify an extension, we check which extension
-        // corresponds to the given file. Extension priority is determined by
-        // the order in which they appear in the possible_extensions array.
-        let possible_files =
-            possible_extensions.iter().map(|extension| path.with_extension(extension));
+    for path in component_paths {
+        let path = if path.extension().is_none() {
+            path.with_extension(COMPONENT_TEMPLATE_EXTENSION)
+        } else {
+            path.clone()
+        };
 
-        let found_file = possible_files.clone().find(|path| path.exists()).ok_or({
-            let looked_files =
-                possible_files.map(|file| format!("- {}\n", file.display())).collect::<String>();
-
+        let bytes = fs::read(components_base_dir.join(&path)).map_err(|e| {
             CliError::AccountComponentError(
-                Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "File not found")),
+                Box::new(e),
+                format!("failed to read account component template from {}", path.display()),
+            )
+        })?;
+        let template = AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
+            CliError::AccountComponentError(
+                Box::new(e),
+                format!("failed to deserialize account component template from {}", path.display()),
+            )
+        })?;
+        templates.push(template);
+    }
+    for path in package_paths {
+        let path = if path.extension().is_none() {
+            path.with_extension(MIDEN_PACKAGE_EXTENSION)
+        } else {
+            path.clone()
+        };
+
+        let bytes = fs::read(packages_dir.join(&path)).map_err(|e| {
+            CliError::AccountComponentError(
+                Box::new(e),
+                format!("failed to read Package from {}", path.display()),
+            )
+        })?;
+
+        let package = Package::read_from_bytes(&bytes).map_err(|e| {
+            CliError::AccountComponentError(
+                Box::new(e),
+                format!("failed to deserialize Package in {}", path.display()),
+            )
+        })?;
+
+        let template = AccountComponentTemplate::try_from(package).map_err(|e| {
+            CliError::AccountComponentError(
+                Box::new(e),
                 format!(
-                    "failed to find {}. None of these files were found:
-{looked_files}",
+                    "failed to read account component template from Package in {}",
                     path.display()
                 ),
             )
         })?;
-
-        std::dbg!("A PUNTO DE LEER");
-        std::dbg!("DONE");
-        let template = match found_file.extension().and_then(|ext| ext.to_str()) {
-            Some(COMPONENT_TEMPLATE_EXTENSION) => {
-                let bytes = fs::read(components_base_dir.join(&found_file))?;
-                AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
-                    CliError::AccountComponentError(
-                        Box::new(e),
-                        format!(
-                            "failed to read account component template from {}",
-                            found_file.display()
-                        ),
-                    )
-                })?
-            },
-            Some(MIDEN_PACKAGE_EXTENSION) => {
-                let bytes = fs::read(packages_dir.join(&found_file))?;
-                let package = Package::read_from_bytes(&bytes).map_err(|e| {
-                    CliError::AccountComponentError(
-                        Box::new(e),
-                        format!(
-                            "failed to read account component template from Package in {}",
-                            found_file.display()
-                        ),
-                    )
-                })?;
-
-                AccountComponentTemplate::try_from(package).map_err(|e| {
-                    CliError::AccountComponentError(
-                        Box::new(e),
-                        format!(
-                            "failed to read account component template from Package in {}",
-                            found_file.display()
-                        ),
-                    )
-                })?
-            },
-            Some(unknown_extension) => {
-                todo!();
-                // let a = 1;
-                // Err(CliError::AccountComponentError((), format!()))
-            },
-            None => {
-                // This case should never occur
-                todo!();
-            },
-        };
-
         templates.push(template);
     }
+
     Ok(templates)
 }
 
@@ -304,10 +298,11 @@ async fn create_client_account<AUTH: TransactionAuthenticator + Sync + 'static>(
     account_type: AccountType,
     storage_mode: AccountStorageMode,
     component_template_paths: &[PathBuf],
+    package_paths: &[PathBuf],
     init_storage_data_path: Option<PathBuf>,
     deploy: bool,
 ) -> Result<Account, CliError> {
-    if component_template_paths.is_empty() {
+    if component_template_paths.is_empty() && package_paths.is_empty() {
         return Err(CliError::InvalidArgument(
             "account must contain at least one component".into(),
         ));
@@ -315,7 +310,7 @@ async fn create_client_account<AUTH: TransactionAuthenticator + Sync + 'static>(
 
     // Load the component templates and initialization storage data.
     debug!("Loading component templates...");
-    let component_templates = load_component_templates(component_template_paths)?;
+    let component_templates = load_component_templates(component_template_paths, package_paths)?;
     debug!("Loaded {} component templates", component_templates.len());
     debug!("Loading initialization storage data...");
     let init_storage_data = load_init_storage_data(init_storage_data_path)?;

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -6,7 +6,7 @@ use std::vec;
 
 use clap::{Parser, ValueEnum};
 use miden_client::Client;
-use miden_client::account::component::COMPONENT_TEMPLATE_EXTENSION;
+use miden_client::account::component::{COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION};
 use miden_client::account::{Account, AccountBuilder, AccountStorageMode, AccountType};
 use miden_client::auth::{AuthSecretKey, TransactionAuthenticator};
 use miden_client::crypto::SecretKey;
@@ -153,8 +153,8 @@ pub struct NewAccountCmd {
     /// Account type to create.
     #[arg(long, value_enum)]
     pub account_type: CliAccountType,
-    /// Optional list of files specifying additional component template files to add to the
-    /// account.
+    /// List of files specifying component template files for the account. At
+    /// lease one component template is required.
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
     /// Optional file path to a TOML file containing a list of key/values used for initializing
@@ -206,14 +206,30 @@ fn load_component_templates(paths: &[PathBuf]) -> Result<Vec<AccountComponentTem
     let (cli_config, _) = load_config_file()?;
     let components_base_dir = &cli_config.component_template_directory;
     let mut templates = Vec::new();
+
+    let possible_extensions = [COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION];
     for path in paths {
-        // Set extension to COMPONENT_TEMPLATE_EXTENSION in case user did not
-        let path = if path.extension().is_none() {
-            path.with_extension(COMPONENT_TEMPLATE_EXTENSION)
-        } else {
-            path.clone()
-        };
-        let bytes = fs::read(components_base_dir.join(path))?;
+        // If the user did not specify an extension, we check which extension
+        // corresponds to the given file. Extension priority is determined by
+        // the order in which they appear in the possible_extensions array.
+        let possible_files =
+            possible_extensions.iter().map(|extension| path.with_extension(extension));
+
+        let found_file = possible_files.clone().find(|path| path.exists()).ok_or({
+            let looked_files =
+                possible_files.map(|file| format!("- {}\n", file.display())).collect::<String>();
+
+            CliError::AccountComponentError(
+                Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "File not found")),
+                format!(
+                    "failed to find {}. None of these files were found:
+{looked_files}",
+                    path.display()
+                ),
+            )
+        })?;
+
+        let bytes = fs::read(components_base_dir.join(found_file))?;
         let template = AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
             CliError::AccountComponentError(
                 Box::new(e),

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -157,7 +157,7 @@ pub struct NewAccountCmd {
     #[arg(long, value_enum)]
     pub account_type: CliAccountType,
     /// List of files specifying component template files for the account. At
-    /// lease one component template is required.
+    /// least one component template is required.
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
     /// List of files containing a Miden Package in `.masp` form from which a

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -156,8 +156,8 @@ pub struct NewAccountCmd {
     /// lease one component template is required.
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
-    /// List of [[miden_core::vm::Package]]s from where a component template is going to be extracted.
-    /// lease one component template is required.
+    /// List of files containing a Miden Package in `.masp` form from which a
+    /// component template is extracted.
     #[arg(short, long)]
     pub packages: Vec<PathBuf>,
     /// Optional file path to a TOML file containing a list of key/values used for initializing
@@ -207,46 +207,53 @@ impl NewAccountCmd {
 type ComponentPath = PathBuf;
 type PackagePath = PathBuf;
 /// Reads component templates from the given file paths.
-// TODO: IO errors should have more context
 fn load_component_templates(
     component_paths: &[ComponentPath],
     package_paths: &[PackagePath],
 ) -> Result<Vec<AccountComponentTemplate>, CliError> {
     let (cli_config, _) = load_config_file()?;
-    let components_base_dir = &cli_config.component_template_directory;
-    let packages_dir = &cli_config.package_directory;
     let mut templates = Vec::new();
 
-    let possible_extensions = [COMPONENT_TEMPLATE_EXTENSION, MIDEN_PACKAGE_EXTENSION];
+    let components_base_dir = &cli_config.component_template_directory;
     for path in component_paths {
         let path = if path.extension().is_none() {
             path.with_extension(COMPONENT_TEMPLATE_EXTENSION)
         } else {
             path.clone()
         };
+        let path = components_base_dir.join(&path);
 
-        let bytes = fs::read(components_base_dir.join(&path)).map_err(|e| {
+        let bytes = fs::read(&path).map_err(|e| {
             CliError::AccountComponentError(
                 Box::new(e),
                 format!("failed to read account component template from {}", path.display()),
             )
         })?;
+
         let template = AccountComponentTemplate::read_from_bytes(&bytes).map_err(|e| {
             CliError::AccountComponentError(
                 Box::new(e),
                 format!("failed to deserialize account component template from {}", path.display()),
             )
         })?;
+
         templates.push(template);
     }
+
+    let packages_dir = &cli_config.package_directory;
     for path in package_paths {
+        // If a user passes in a file with the `.masp` file extension, then we
+        // leave the passed in path as is; since it probably is a full path.
+        // This is the case with cargo-miden, which displays the full path to
+        // stdout after compilation finishes.
         let path = if path.extension().is_none() {
-            path.with_extension(MIDEN_PACKAGE_EXTENSION)
+            let path = path.with_extension(MIDEN_PACKAGE_EXTENSION);
+            packages_dir.join(&path)
         } else {
             path.clone()
         };
 
-        let bytes = fs::read(packages_dir.join(&path)).map_err(|e| {
+        let bytes = fs::read(&path).map_err(|e| {
             CliError::AccountComponentError(
                 Box::new(e),
                 format!("failed to read Package from {}", path.display()),
@@ -269,6 +276,7 @@ fn load_component_templates(
                 ),
             )
         })?;
+
         templates.push(template);
     }
 

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -220,14 +220,24 @@ fn load_component_templates(
     let components_base_dir = &cli_config.component_template_directory;
     for path in component_paths {
         let file_name = match path.extension() {
-            None => Ok(path.with_extension(COMPONENT_TEMPLATE_EXTENSION)),
+            None => {
+                // Set extension to COMPONENT_TEMPLATE_EXTENSION in case user
+                // did not
+                Ok(path.with_extension(COMPONENT_TEMPLATE_EXTENSION))
+            },
             Some(extension) => {
                 if extension != OsStr::new(COMPONENT_TEMPLATE_EXTENSION) {
+                    let error = std::io::Error::new(
+                        std::io::ErrorKind::InvalidFilename,
+                        format!(
+                            "{} has an invalid file extension: '{}'. \
+                            Expected: {COMPONENT_TEMPLATE_EXTENSION}",
+                            path.display(),
+                            extension.display()
+                        ),
+                    );
                     Err(CliError::AccountComponentError(
-                        Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidFilename,
-                            format!("{} has an invalid file extension: {}. Expected: {COMPONENT_TEMPLATE_EXTENSION}", path.display(), extension.display()),
-                        )),
+                        Box::new(error),
                         format!(
                             "failed to read account component template from {}",
                             path.display()
@@ -270,15 +280,18 @@ fn load_component_templates(
             },
             Some(extension) => {
                 if extension != OsStr::new(MIDEN_PACKAGE_EXTENSION) {
-                    Err(CliError::AccountComponentError(
-                        Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidFilename,
-                            format!("{} has an invalid file extension: {}. Expected: {MIDEN_PACKAGE_EXTENSION}", path.display(), extension.display()),
-                        )),
+                    let error = std::io::Error::new(
+                        std::io::ErrorKind::InvalidFilename,
                         format!(
-                            "failed to read Package from {}",
-                            path.display()
+                            "{} has an invalid file extension: '{}'. \
+                            Expected: {MIDEN_PACKAGE_EXTENSION}",
+                            path.display(),
+                            extension.display()
                         ),
+                    );
+                    Err(CliError::AccountComponentError(
+                        Box::new(error),
+                        format!("failed to read Package from {}", path.display()),
                     ))
                 } else {
                     Ok(path.clone())

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -86,6 +86,10 @@ pub struct NewWalletCmd {
     /// Optional list of files specifying additional components to add to the account.
     #[arg(short, long)]
     pub extra_components: Vec<PathBuf>,
+    /// Optional list of files containing a Miden Package in `.masp` form from which a
+    /// component template can be extracted.
+    #[arg(short, long)]
+    pub packages: Vec<PathBuf>,
     /// Optional file path to a TOML file containing a list of key/values used for initializing
     /// storage. Each of these keys should map to the templated storage values within the passed
     /// list of component templates. The user will be prompted to provide values for any keys not
@@ -120,7 +124,7 @@ impl NewWalletCmd {
             account_type,
             self.storage_mode.into(),
             &component_template_paths,
-            &[],
+            &self.packages,
             self.init_storage_data_path.clone(),
             self.deploy,
         )
@@ -156,11 +160,13 @@ pub struct NewAccountCmd {
     /// Account type to create.
     #[arg(long, value_enum)]
     pub account_type: CliAccountType,
-    /// List of files specifying component template files for the account. At
-    /// least one component template is required.
+    /// List of files specifying component template files for the account.
+    /// At least one component template is required, either specified by
+    /// [[NewAccountCmd::component_templates]] or by [[NewAccountCmd::packages]].
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
     /// List of files containing a Miden Package in `.masp` form from which a
+
     /// component template is extracted.
     #[arg(short, long)]
     pub packages: Vec<PathBuf>,

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -162,11 +162,10 @@ pub struct NewAccountCmd {
     pub account_type: CliAccountType,
     /// List of files specifying component template files for the account.
     /// At least one component template is required, either specified by
-    /// [[NewAccountCmd::component_templates]] or by [[NewAccountCmd::packages]].
+    /// [[`NewAccountCmd::component_templates`]] or by [[`NewAccountCmd::packages`]].
     #[arg(short, long)]
     pub component_templates: Vec<PathBuf>,
     /// List of files containing a Miden Package in `.masp` form from which a
-
     /// component template is extracted.
     #[arg(short, long)]
     pub packages: Vec<PathBuf>,

--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -12,6 +12,7 @@ use crate::errors::CliError;
 
 const TOKEN_SYMBOL_MAP_FILEPATH: &str = "token_symbol_map.toml";
 const DEFAULT_COMPONENT_TEMPLATE_DIR: &str = "./templates";
+const DEFAULT_PACKAGES_DIR: &str = "./packages";
 
 // CLI CONFIG
 // ================================================================================================

--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -33,6 +33,8 @@ pub struct CliConfig {
     pub remote_prover_endpoint: Option<CliEndpoint>,
     /// Path to the directory from where account component template files will be loaded.
     pub component_template_directory: PathBuf,
+    /// Path to the directory from where [[miden_core::vm::Package]]s will be loaded.
+    pub package_directory: PathBuf,
     /// Maximum number of blocks the client can be behind the network for transactions and account
     /// proofs to be considered valid.
     pub max_block_number_delta: Option<u32>,
@@ -70,6 +72,7 @@ impl Default for CliConfig {
             token_symbol_map_filepath: Path::new(TOKEN_SYMBOL_MAP_FILEPATH).to_path_buf(),
             remote_prover_endpoint: None,
             component_template_directory: Path::new(DEFAULT_COMPONENT_TEMPLATE_DIR).to_path_buf(),
+            package_directory: Path::new(DEFAULT_PACKAGES_DIR).to_path_buf(),
             max_block_number_delta: None,
         }
     }

--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -33,7 +33,7 @@ pub struct CliConfig {
     pub remote_prover_endpoint: Option<CliEndpoint>,
     /// Path to the directory from where account component template files will be loaded.
     pub component_template_directory: PathBuf,
-    /// Path to the directory from where [[miden_core::vm::Package]]s will be loaded.
+    /// Path to the directory from where [[`miden_core::vm::Package`]]s will be loaded.
     pub package_directory: PathBuf,
     /// Maximum number of blocks the client can be behind the network for transactions and account
     /// proofs to be considered valid.

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -71,6 +71,7 @@ use crate::store::{AccountRecord, AccountStatus};
 
 pub mod component {
     pub const COMPONENT_TEMPLATE_EXTENSION: &str = "mct";
+    pub const MIDEN_PACKAGE_EXTENSION: &str = "masp";
 
     pub use miden_lib::account::auth::AuthRpoFalcon512;
     pub use miden_lib::account::faucets::{BasicFungibleFaucet, FungibleFaucetExt};


### PR DESCRIPTION
This PR adds makes it so that the CLI can now extract a component template from a passed in package, via the `-p, --packages` flags.
Additionally, this TODO comment was addressed, now the I/O error display more context. 

Here are snippets showcasing the new error messages:
```
  × account component error: failed to read account component template from component.mca
  ╰─▶ component.mca has an invalid file extension: 'mca'. Expected: mct
 ```
 ```
   × account component error: failed to read account component template from ./templates/component.mct
  ╰─▶ No such file or directory (os error 2)
  ```
  ```
    × account component error: failed to read Package from ./packages/component.masp
  ╰─▶ No such file or directory (os error 2)
```
```
  × account component error: failed to read Package from component.masl
  ╰─▶ component.masl has an invalid file extension: 'masl'. Expected: masp
```